### PR TITLE
Reinstate pull button

### DIFF
--- a/services/web/app/src/Features/Git/GitController.js
+++ b/services/web/app/src/Features/Git/GitController.js
@@ -58,8 +58,9 @@ async function resetDatabase(projectId, userId, projectPath) {
   }
 }
 
-async function buildProject(currentPath, projectId, ownerId, parentId){
+async function buildProject(currentPath, projectId, ownerId, parentId) {
 
+  resetDatabase(projectId, ownerId, currentPath) //
   const items = await fs.readdir(currentPath)
 
   for (const item of items) {
@@ -339,65 +340,66 @@ GitController = {
     console.log("Commit " + filePath + " in " + projectPath)
     res.sendStatus(200)
   },
+  //
+  // pull(req, res) {
+  //   const projectId = req.body.projectId;
+  //   const userId = req.body.userId;
+  //   const projectPath = dataPath + projectId + "-" + userId;
+  //
+  //   console.log("Pulling");
+  //
+  //   getKey(userId, 'private')
+  //       .then(key => {
+  //         const GIT_SSH_COMMAND = `ssh -o StrictHostKeyChecking=no -i ${key}`;
+  //         git = simpleGit().env({ 'GIT_SSH_COMMAND': GIT_SSH_COMMAND });
+  //         return move(projectId, userId);
+  //       })
+  //       // .then(() => git.pull({ '--no-rebase': null }))
+  //       .then(() => git.fetch())
+  //       .then(() => {
+  //         const mergeSummary = simpleGit().merge();
+  //         console.log(`Merged ${mergeSummary.merges.length} files`);
+  //         console.log("Repository pulled");
+  //         return buildProject(projectPath, projectId, userId, getRootId(projectId));
+  //         res.sendStatus(200) })
+  //       .catch (err => {
+  //         const mergeSummary: MergeSummary = (err as GitResponseError<MergeSummary>).git;
+  //         const conflicts = mergeSummary?.conflicts || [];
+  //
+  //         console.error(`Merge resulted in ${conflicts.length} conflicts`);
+  //         console.error(`Merge error: ${err.message}`);
+  //         console.error(`err.stack: ${err.stack}`);
+  //         console.error(`err.git: ${err.git}`);
+  //         res.sendStatus(500);
+  //         })
+  //   },
+
+
     pull(req, res) {
-        const projectId = req.body.projectId;
-        const userId = req.body.userId;
-        const projectPath = dataPath + projectId + "-" + userId;
+      const projectId = req.body.projectId
+      const userId = req.body.userId
+      const projectPath = dataPath + projectId + "-" + userId
 
-        console.log("Pulling");
+      console.log("Pulling")
 
-        resetDatabase(projectId, userId, projectPath)
-            .then(() => getKey(userId, 'private'))
-            .then(key => {
-                const GIT_SSH_COMMAND = `ssh -o StrictHostKeyChecking=no -i ${key}`;
-                git = simpleGit().env({ 'GIT_SSH_COMMAND': GIT_SSH_COMMAND });
-                return move(projectId, userId);
-            })
-            .then(() => git.pull({ '--rebase': 'true' }))
-            .then(update => {
-                console.log("Repository pulled");
-                return buildProject(projectPath, projectId, userId, getRootId(projectId));
-            })
-            .then(() => res.sendStatus(200))
-            .catch(async (error) => {
-                console.error("Error:", error);
-                try {
-                    await resetDatabase(projectId, userId, projectPath);
-                    res.status(500).json({ message: "An error occurred. Changes reverted." });
-                } catch (restoreError) {
-                    console.error("Restore failed:", restoreError);
-                    res.status(500).json({ message: "Critical error. Could not revert changes." });
-                }
-            });
+      getKey(userId, 'private')
+        .then(key => {
+          const GIT_SSH_COMMAND = `ssh -o StrictHostKeyChecking=no -i ${key}`;
+          git = simpleGit().env({'GIT_SSH_COMMAND': GIT_SSH_COMMAND});
+          return move(projectId, userId)
+        })
+        .then(() => git.pull())
+        .then(update => {
+          console.log("Repository pulled");
+          return buildProject(projectPath, projectId, userId, getRootId(projectId));
+        })
+        .then(() => res.sendStatus(200))
+        .catch(error => {
+          console.error("Error:", error);
+          res.sendStatus(500);
+        });
     },
 
-    /*
-      pull(req, res) {
-        const projectId = req.body.projectId
-        const userId = req.body.userId
-        const projectPath = dataPath + projectId + "-" + userId
-
-        console.log("Pulling")
-
-        resetDatabase(projectId, userId, projectPath)
-        .then(() => getKey(userId, 'private'))
-          .then(key => {
-            const GIT_SSH_COMMAND = `ssh -o StrictHostKeyChecking=no -i ${key}`;
-            git = simpleGit().env({'GIT_SSH_COMMAND': GIT_SSH_COMMAND});
-            return move(projectId, userId)
-          })
-          .then(() => git.pull())
-          .then(update => {
-            console.log("Repository pulled");
-            return buildProject(projectPath, projectId, userId, getRootId(projectId));
-          })
-          .then(() => res.sendStatus(200))
-          .catch(error => {
-            console.error("Error:", error);
-            res.sendStatus(500);
-          });
-      },
-    */
   add(req, res) {
     const projectId = req.body.projectId
     const userId = req.body.userId

--- a/services/web/app/src/Features/Git/GitController.js
+++ b/services/web/app/src/Features/Git/GitController.js
@@ -340,75 +340,33 @@ GitController = {
     console.log("Commit " + filePath + " in " + projectPath)
     res.sendStatus(200)
   },
-  //
-  // pull(req, res) {
-  //   const projectId = req.body.projectId;
-  //   const userId = req.body.userId;
-  //   const projectPath = dataPath + projectId + "-" + userId;
-  //
-  //   console.log("Pulling");
-  //
-  //   getKey(userId, 'private')
-  //       .then(key => {
-  //         const GIT_SSH_COMMAND = `ssh -o StrictHostKeyChecking=no -i ${key}`;
-  //         git = simpleGit().env({ 'GIT_SSH_COMMAND': GIT_SSH_COMMAND });
-  //         return move(projectId, userId);
-  //       })
-  //       // .then(() => git.pull({ '--no-rebase': null }))
-  //       .then(() => git.fetch())
-  //       .then(() => {
-  //         const mergeSummary = simpleGit().merge();
-  //         console.log(`Merged ${mergeSummary.merges.length} files`);
-  //         console.log("Repository pulled");
-  //         return buildProject(projectPath, projectId, userId, getRootId(projectId));
-  //         res.sendStatus(200) })
-  //       .catch (err => {
-  //         const mergeSummary: MergeSummary = (err as GitResponseError<MergeSummary>).git;
-  //         const conflicts = mergeSummary?.conflicts || [];
-  //
-  //         console.error(`Merge resulted in ${conflicts.length} conflicts`);
-  //         console.error(`Merge error: ${err.message}`);
-  //         console.error(`err.stack: ${err.stack}`);
-  //         console.error(`err.git: ${err.git}`);
-  //         res.sendStatus(500);
-  //         })
-  //   },
 
+  pull(req, res) {
+    const projectId = req.body.projectId
+    const userId = req.body.userId
+    const projectPath = dataPath + projectId + "-" + userId
 
-    pull(req, res) {
-      const projectId = req.body.projectId
-      const userId = req.body.userId
-      const projectPath = dataPath + projectId + "-" + userId
+    console.log("Pulling")
 
-      console.log("Pulling")
-
-      getKey(userId, 'private')
-        .then(key => {
-          const GIT_SSH_COMMAND = `ssh -o StrictHostKeyChecking=no -i ${key}`;
-          git = simpleGit().env({'GIT_SSH_COMMAND': GIT_SSH_COMMAND});
-          return move(projectId, userId)
-        })
-        .then(() => git.listRemote())
-        // git fetch and merge preferred because pull interface does not show full error: https://github.com/steveukx/git-js/issues/625
-        // .then(() => git.fetch())
-        // .then(() => git.merge(['--no-rebase']))
-        .then(() => git.pull({'--no-rebase': null}))
-        .then(update => {
-          console.log("Repository pulled");
-          return buildProject(projectPath, projectId, userId, getRootId(projectId));
-        })
-        .then(() => res.sendStatus(200))
-        // .catch(error => {
-        //   console.log("Git diff", git.diff(["HEAD", "origin/main"]) );
-        //   console.log("Git diff", git.diffSummary() );
-        // })
-        .catch(error => {
-
-          console.error("Error:", error);
-          res.sendStatus(500);
-          return buildProject(projectPath, projectId, userId, getRootId(projectId));
-        });
-    },
+    getKey(userId, 'private')
+      .then(key => {
+        const GIT_SSH_COMMAND = `ssh -o StrictHostKeyChecking=no -i ${key}`;
+        git = simpleGit().env({'GIT_SSH_COMMAND': GIT_SSH_COMMAND});
+        return move(projectId, userId)
+      })
+      .then(() => git.listRemote())
+      .then(() => git.pull({'--no-rebase': null}))
+      .then(update => {
+        console.log("Repository pulled");
+        return buildProject(projectPath, projectId, userId, getRootId(projectId));
+      })
+      .then(() => res.sendStatus(200))
+      .catch(error => {
+        console.error("Error:", error);
+        res.sendStatus(500);
+        return buildProject(projectPath, projectId, userId, getRootId(projectId));
+      });
+  },
 
   add(req, res) {
     const projectId = req.body.projectId

--- a/services/web/app/src/Features/Git/GitController.js
+++ b/services/web/app/src/Features/Git/GitController.js
@@ -60,7 +60,7 @@ async function resetDatabase(projectId, userId, projectPath) {
 
 async function buildProject(currentPath, projectId, ownerId, parentId) {
 
-  resetDatabase(projectId, ownerId, currentPath) //
+  resetDatabase(projectId, ownerId, currentPath)
   const items = await fs.readdir(currentPath)
 
   for (const item of items) {
@@ -354,7 +354,6 @@ GitController = {
         git = simpleGit().env({'GIT_SSH_COMMAND': GIT_SSH_COMMAND});
         return move(projectId, userId)
       })
-      .then(() => git.listRemote())
       .then(() => git.pull({'--no-rebase': null}))
       .then(update => {
         console.log("Repository pulled");

--- a/services/web/app/src/Features/Git/GitController.js
+++ b/services/web/app/src/Features/Git/GitController.js
@@ -388,15 +388,25 @@ GitController = {
           git = simpleGit().env({'GIT_SSH_COMMAND': GIT_SSH_COMMAND});
           return move(projectId, userId)
         })
-        .then(() => git.pull())
+        .then(() => git.listRemote())
+        // git fetch and merge preferred because pull interface does not show full error: https://github.com/steveukx/git-js/issues/625
+        // .then(() => git.fetch())
+        // .then(() => git.merge(['--no-rebase']))
+        .then(() => git.pull({'--no-rebase': null}))
         .then(update => {
           console.log("Repository pulled");
           return buildProject(projectPath, projectId, userId, getRootId(projectId));
         })
         .then(() => res.sendStatus(200))
+        // .catch(error => {
+        //   console.log("Git diff", git.diff(["HEAD", "origin/main"]) );
+        //   console.log("Git diff", git.diffSummary() );
+        // })
         .catch(error => {
+
           console.error("Error:", error);
           res.sendStatus(500);
+          return buildProject(projectPath, projectId, userId, getRootId(projectId));
         });
     },
 

--- a/services/web/frontend/js/features/editor-navigation-toolbar/components/git-toggle-button.jsx
+++ b/services/web/frontend/js/features/editor-navigation-toolbar/components/git-toggle-button.jsx
@@ -23,7 +23,7 @@ function Modal({ isOpen, onClose, onCommit, onPush, notStagedFiles, stagedFiles}
           <h2 style={{ fontFamily: 'sans-serif', fontWeight: 500 }}>Git Menu</h2>
           <div>
             <label htmlFor="commit-message" style={{ color: 'black' }}>Commit message</label>
-            <textarea id="commit-message" rows="4" style={{ width: '100%' }}></textarea>
+            <textarea id="commit-message" rows="4" style={{ color: 'dimgray', width: '100%' }}></textarea>
           </div>
           <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
             <button onClick={onCommit} style={{ color: 'black', width: '100%', marginBottom: '10px' }}>Commit</button>

--- a/services/web/frontend/js/features/editor-navigation-toolbar/components/git-toggle-button.jsx
+++ b/services/web/frontend/js/features/editor-navigation-toolbar/components/git-toggle-button.jsx
@@ -22,18 +22,18 @@ function Modal({ isOpen, onClose, onCommit, onPush, notStagedFiles, stagedFiles}
         <div className="modal-content">
           <h2 style={{ fontFamily: 'sans-serif', fontWeight: 500 }}>Git Menu</h2>
           <div>
-            <label htmlFor="commit-message">Commit message</label>
+            <label htmlFor="commit-message" style={{ color: 'black' }}>Commit message</label>
             <textarea id="commit-message" rows="4" style={{ width: '100%' }}></textarea>
           </div>
           <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <button onClick={onCommit} style={{ width: '100%', marginBottom: '10px' }}>Commit</button>
-            <button onClick={onPush} style={{ width: '100%' }}>Push</button>
+            <button onClick={onCommit} style={{ color: 'black', width: '100%', marginBottom: '10px' }}>Commit</button>
+            <button onClick={onPush} style={{ color: 'black', width: '100%' }}>Push</button>
           </div>
         <div style={{ marginTop: '20px' }}>
           <h3>Modified files (not staged)</h3>
           <ul>
             {notStagedFiles.map((file, index) => (
-              <li key={index}>{file}</li>
+              <li key={index} style={{ color: 'black' }}>{file}</li>
             ))}
           </ul>
         </div>
@@ -41,7 +41,7 @@ function Modal({ isOpen, onClose, onCommit, onPush, notStagedFiles, stagedFiles}
           <h3>Staged files</h3>
           <ul>
             {stagedFiles.map((file, index) => (
-              <li key={index}>{file}</li>
+              <li key={index} style={{ color: 'black' }}>{file}</li>
             ))}
           </ul>
         </div>

--- a/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
+++ b/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
@@ -110,7 +110,7 @@ function FileTreeToolbarLeft() {
             })
         );
       }}>
-        <Icon type="upload" fw accessibilityLabel={t('upload')} />
+        <Icon type="file" fw accessibilityLabel={t('upload')} />
       </Button>
     </Tooltip>
     </div>

--- a/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
+++ b/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
@@ -110,7 +110,7 @@ function FileTreeToolbarLeft() {
             })
         );
       }}>
-        <Icon type="file" fw accessibilityLabel={t('upload')} />
+        <Icon type="sync" fw accessibilityLabel={t('pull')} />
       </Button>
     </Tooltip>
     </div>

--- a/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
+++ b/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
@@ -110,7 +110,7 @@ function FileTreeToolbarLeft() {
             })
         );
       }}>
-        <Icon type="rotate" fw accessibilityLabel={t('pull')} />
+        <Icon type="code-pull-request" fw accessibilityLabel={t('pull')} />
       </Button>
     </Tooltip>
     </div>

--- a/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
+++ b/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
@@ -110,7 +110,7 @@ function FileTreeToolbarLeft() {
             })
         );
       }}>
-        <Icon type="sync" fw accessibilityLabel={t('pull')} />
+        <Icon type="rotate" fw accessibilityLabel={t('pull')} />
       </Button>
     </Tooltip>
     </div>

--- a/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
+++ b/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
@@ -110,7 +110,7 @@ function FileTreeToolbarLeft() {
             })
         );
       }}>
-        <Icon type="code-pull-request" fw accessibilityLabel={t('pull')} />
+        <Icon type="repeat" fw accessibilityLabel={t('pull')} />
       </Button>
     </Tooltip>
     </div>

--- a/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
+++ b/services/web/frontend/js/features/file-tree/components/file-tree-toolbar.tsx
@@ -95,6 +95,24 @@ function FileTreeToolbarLeft() {
           <Icon type="upload" fw accessibilityLabel={t('upload')} />
         </Button>
       </Tooltip>
+      <Tooltip
+        id="pull"
+        description='Pull'
+        overlayProps={{ placement: 'bottom' }}
+      >
+      <Button onClick={() => {
+        runAsync(
+            postJSON('/git-pull', {
+              body:{
+                projectId: projectId,
+                userId: userId
+              }
+            })
+        );
+      }}>
+        <Icon type="upload" fw accessibilityLabel={t('upload')} />
+      </Button>
+    </Tooltip>
     </div>
   )
 }


### PR DESCRIPTION
goal: fix the pull button

previously: 
the "self distruct" behaviour occurs because the `resetDatabase` is always called, and `buildDatabase` is not called when there are errors thrown.

changes made:
- `resetDatabase` is only called from `buildDatabase`
- when there are errors, `buildDatabase` is called in the catch block to render the conflicts `>>>> HEAD ... `
- git pull with `--no-rebase`
- aesthetic changes

ready for merge!