### PR TITLE
add sandboxed compile feature (code from yu-i-i/overleaf-cep)

### DIFF
--- a/server-ce/config/settings.js
+++ b/server-ce/config/settings.js
@@ -448,6 +448,42 @@ switch (process.env.OVERLEAF_FILESTORE_BACKEND) {
       },
     }
 }
+// Overleaf Extended CE Compiler options to enable sandboxed compiles.
+
+
+// -----------
+if (process.env.SANDBOXED_COMPILES === 'true') {
+  settings.clsi = {
+    ...settings.clsi,
+    dockerRunner: true,
+    docker: {
+      image: process.env.TEX_LIVE_DOCKER_IMAGE,
+      env: {
+        HOME: '/tmp',
+        PATH:
+          process.env.COMPILER_PATH ||
+          '/usr/local/bin:/usr/bin:/bin',
+      },
+      user: 'www-data',
+    }
+  }
+
+  if (settings.path == null) {
+    settings.path = {}
+  }
+  settings.path.synctexBaseDir = () => '/compile'
+  if (process.env.SANDBOXED_COMPILES_SIBLING_CONTAINERS === 'true') {
+    console.log('Using sibling containers for sandboxed compiles')
+    if (process.env.SANDBOXED_COMPILES_HOST_DIR) {
+      settings.path.sandboxedCompilesHostDir =
+        process.env.SANDBOXED_COMPILES_HOST_DIR
+    } else {
+      console.error(
+        'Sibling containers, but SANDBOXED_COMPILES_HOST_DIR not set'
+      )
+    }
+  }
+}
 
 // With lots of incoming and outgoing HTTP connections to different services,
 // sometimes long running, it is a good idea to increase the default number


### PR DESCRIPTION
## Description
possibility to activate sandboxed compiles : ie each compilation process is triggered in a separate docker container

## To test : 
SERVER_PRO=true
SIBLING_CONTAINERS_ENABLED=true 
in overleaf.rc 

and 
ALL_TEX_LIVE_DOCKER_IMAGES=texlive/texlive:latest-full, texlive/texlive:TL2024-historic
ALL_TEX_LIVE_DOCKER_IMAGE_NAMES=TeXLive 2024, TeXLive 2023
TEX_LIVE_DOCKER_IMAGE=texlive/texlive:latest-full
TEX_COMPILER_EXTRA_FLAGS=-shell-escape
in variables.env file

